### PR TITLE
Add prom-client dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "prom-client": "^14.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- include `prom-client` in the app dependencies

## Testing
- `npm install --package-lock-only --prefer-offline` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846b210a34c833181bd08decfe999b4