### PR TITLE
Add k8s health probes

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,3 +19,15 @@ spec:
           image: kaveeshadev/devops-pipeline-app:latest
           ports:
             - containerPort: 3000
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10


### PR DESCRIPTION
## Summary
- add livenessProbe and readinessProbe to k8s deployment

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2244b2c8331969b4ffce233afdb