### PR TITLE
Add imagePullPolicy to k8s deployment

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -17,5 +17,6 @@ spec:
       containers:
         - name: devops-pipeline-app-container
           image: kaveeshadev/devops-pipeline-app:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 3000


### PR DESCRIPTION
## Summary
- ensure the container always pulls the latest image by adding `imagePullPolicy: Always` to `k8s/deployment.yaml`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846b219a2308331b468af57329943f2